### PR TITLE
Fix typo for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           mkdocs build
 
       - name: Deploy
-          uses: amesIves/github-pages-deploy-action@13046b614c663b56cba4dda3f30b9736a748b80d #@v4
+          uses: JamesIves/github-pages-deploy-action@13046b614c663b56cba4dda3f30b9736a748b80d #@v4
           with:
             folder: site
             branch: gh-pages # default


### PR DESCRIPTION
Closes #17 

I've noticed the documentation does not get published from `main`. I suspect it is because of this typo in publish.yml