### PR TITLE
Replace hash with version tag in deploy action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           mkdocs build
 
       - name: Deploy
-          uses: JamesIves/github-pages-deploy-action@13046b614c663b56cba4dda3f30b9736a748b80d #@v4
+          uses: JamesIves/github-pages-deploy-action@v4
           with:
             folder: site
             branch: gh-pages # default


### PR DESCRIPTION
Site is not deploying correctly when PRs are merged. Seems using the commit hash doesn't work, it is picking up an old version of the action (`v1`). 

Using the [commit hash is supposed to be more secure](https://blog.gitguardian.com/github-actions-security-cheat-sheet/), but not sure it works. Reverting to using the version string.

